### PR TITLE
Add CardID abstraction

### DIFF
--- a/BinaryMatrixEngine/Card.cs
+++ b/BinaryMatrixEngine/Card.cs
@@ -61,6 +61,15 @@ public readonly struct CardID : IEquatable<CardID> {
 
 	public static readonly IReadOnlyList<CardID> allIDs;
 
+	override public string ToString() {
+		return this.IsUnknown ? "X" :
+				new string(new [] {
+					Card.ValueToSymbol(this.value),
+					Card.AxiomToSymbol(this.axiom)
+				})
+		;
+	}
+
 	public bool Equals(CardID other) => this.axiom == other.axiom && this.value == other.value;
 	override public bool Equals(object? obj) => obj is CardID other && Equals(other);
 	override public int GetHashCode() => HashCode.Combine((int) this.axiom, (int) this.value);
@@ -162,12 +171,7 @@ public struct Card : IEquatable<Card> {
 	}
 
 	override public string ToString() {
-		if(this.value == 0 || this.axiom == 0)
-			return "(( DEFAULT CARD ))";
-		if(this.IsInvalid)
-			return "(( INVALID CARD ))";
-
-		return new string(new [] { ValueToSymbol(this.value), AxiomToSymbol(this.axiom) });
+		return this.ID + (this.revealed ? "u" : "");
 	}
 
 	public string DebugDisplay() {

--- a/BinaryMatrixEngine/Card.cs
+++ b/BinaryMatrixEngine/Card.cs
@@ -64,51 +64,17 @@ public readonly struct CardID : IEquatable<CardID> {
 	override public string ToString() {
 		return this.IsUnknown ? "X" :
 				new string(new [] {
-					Card.ValueToSymbol(this.value),
-					Card.AxiomToSymbol(this.axiom)
+					ValueToSymbol(this.value),
+					AxiomToSymbol(this.axiom)
 				})
 		;
 	}
 
 	public bool Equals(CardID other) => this.axiom == other.axiom && this.value == other.value;
-	override public bool Equals(object? obj) => obj is CardID other && Equals(other);
+	override public bool Equals(object? obj) => obj is CardID other && this.Equals(other);
 	override public int GetHashCode() => HashCode.Combine((int) this.axiom, (int) this.value);
 	public static bool operator ==(CardID left, CardID right) => left.Equals(right);
 	public static bool operator !=(CardID left, CardID right) => !left.Equals(right);
-}
-
-[DebuggerDisplay("{DebugDisplay()}")]
-public struct Card : IEquatable<Card> {
-	public readonly CardID ID;
-	/* @@suppress-name-violation: migration */
-	public readonly Axiom axiom => this.ID.axiom;
-	/* @@suppress-name-violation: migration */
-	public readonly Value value => this.ID.value;
-	public bool revealed = false;
-
-	public Card(CardID id) {
-		this.ID = id;
-	}
-
-	public Card(Axiom axiom, Value value) {
-		this.ID = new CardID(axiom, value);
-	}
-
-	/* A particular card cannot ever have an unknown ID. */
-	public bool IsInvalid => this.ID.IsUnknown;
-
-	public bool Equals(Card other) => this.ID == other.ID;
-	override public bool Equals(object? obj) => obj is Card other && this.Equals(other);
-	override public int GetHashCode() => this.ID.GetHashCode();
-
-	public static bool operator ==(Card left, Card right) => left.Equals(right);
-	public static bool operator !=(Card left, Card right) => !left.Equals(right);
-
-	static Card() {
-		allCards = CardID.allIDs.Select(x => new Card(x)).ToImmutableList();
-	}
-
-	public static readonly IReadOnlyList<Card> allCards;
 
 	public static Axiom? AxiomFromSymbol(char c) {
 		return c switch {
@@ -169,6 +135,40 @@ public struct Card : IEquatable<Card> {
 			Value.TRAP => '@'
 		};
 	}
+}
+
+[DebuggerDisplay("{DebugDisplay()}")]
+public struct Card : IEquatable<Card> {
+	public readonly CardID ID;
+	/* @@suppress-name-violation: migration */
+	public readonly Axiom axiom => this.ID.axiom;
+	/* @@suppress-name-violation: migration */
+	public readonly Value value => this.ID.value;
+	public bool revealed = false;
+
+	public Card(CardID id) {
+		this.ID = id;
+	}
+
+	public Card(Axiom axiom, Value value) {
+		this.ID = new CardID(axiom, value);
+	}
+
+	/* A particular card cannot ever have an unknown ID. */
+	public bool IsInvalid => this.ID.IsUnknown;
+
+	public bool Equals(Card other) => this.ID == other.ID;
+	override public bool Equals(object? obj) => obj is Card other && this.Equals(other);
+	override public int GetHashCode() => this.ID.GetHashCode();
+
+	public static bool operator ==(Card left, Card right) => left.Equals(right);
+	public static bool operator !=(Card left, Card right) => !left.Equals(right);
+
+	static Card() {
+		allCards = CardID.allIDs.Select(x => new Card(x)).ToImmutableList();
+	}
+
+	public static readonly IReadOnlyList<Card> allCards;
 
 	override public string ToString() {
 		return this.ID + (this.revealed ? "u" : "");

--- a/BinaryMatrixEngine/Card.cs
+++ b/BinaryMatrixEngine/Card.cs
@@ -140,12 +140,6 @@ public readonly struct CardID : IEquatable<CardID> {
 [DebuggerDisplay("{DebugDisplay()}")]
 public struct Card : IEquatable<Card> {
 	public readonly CardID ID;
-	/* @@suppress-name-violation: migration */
-	[Obsolete("Use `Axiom` instead.")]
-	public readonly Axiom axiom => this.ID.axiom;
-	/* @@suppress-name-violation: migration */
-	[Obsolete("Use `Value` instead.")]
-	public readonly Value value => this.ID.value;
 	public bool revealed = false;
 
 	public readonly Axiom Axiom => this.ID.axiom;

--- a/BinaryMatrixEngine/Card.cs
+++ b/BinaryMatrixEngine/Card.cs
@@ -141,10 +141,15 @@ public readonly struct CardID : IEquatable<CardID> {
 public struct Card : IEquatable<Card> {
 	public readonly CardID ID;
 	/* @@suppress-name-violation: migration */
+	[Obsolete("Use `Axiom` instead.")]
 	public readonly Axiom axiom => this.ID.axiom;
 	/* @@suppress-name-violation: migration */
+	[Obsolete("Use `Value` instead.")]
 	public readonly Value value => this.ID.value;
 	public bool revealed = false;
+
+	public readonly Axiom Axiom => this.ID.axiom;
+	public readonly Value Value => this.ID.value;
 
 	public Card(CardID id) {
 		this.ID = id;

--- a/BinaryMatrixEngine/GameExecution.cs
+++ b/BinaryMatrixEngine/GameExecution.cs
@@ -85,16 +85,16 @@ public static class GameExecution {
 				if(stack.Revealed && action.type == ActionType.PLAY) return OperationError.WRONG_FACING;
 
 				bool stackEmpty = stack.cards.Count == 0;
-				if(card.value == Value.BREAK) {
+				if(card.Value == Value.BREAK) {
 					if(stackEmpty) return OperationError.BREAK_ON_EMPTY;
-					if(player.Role == PlayerRole.DEFENDER && stack.Revealed && stack.cards.Any(x => x.value == Value.BREAK))
+					if(player.Role == PlayerRole.DEFENDER && stack.Revealed && stack.cards.Any(x => x.Value == Value.BREAK))
 						return OperationError.DOUBLE_FACEUP_BREAK_IN_DEFENSE;
 				}
 
 				ref Card newCard = ref stack.cards.Add(player.Hand.Take(index)!.Value);
 				if(action.type == ActionType.FACEUP_PLAY) {
 					newCard.revealed = true;
-					switch(newCard.value) {
+					switch(newCard.Value) {
 						case Value.BREAK:
 						case Value.BOUNCE when stackEmpty && player.Role == PlayerRole.ATTACKER:
 							ResolveCombat(context, lane, player);
@@ -138,7 +138,7 @@ public static class GameExecution {
 			if(card.revealed)
 				continue;
 			card.revealed = true;
-			if(card.value != Value.TRAP || targetDeck.cards.Count <= 0)
+			if(card.Value != Value.TRAP || targetDeck.cards.Count <= 0)
 				continue;
 			Card trapped = targetDeck.cards.TakeLast()!.Value;
 			trapped.revealed = true;
@@ -159,8 +159,8 @@ public static class GameExecution {
 		}
 
 		bool hasBounces =
-			lane.attackerStack.cards.Any(x => x.value == Value.BOUNCE) ||
-			lane.defenderStack.cards.Any(x => x.value == Value.BOUNCE)
+			lane.attackerStack.cards.Any(x => x.Value == Value.BOUNCE) ||
+			lane.defenderStack.cards.Any(x => x.Value == Value.BOUNCE)
 		;
 
 		int apow; int dpow;
@@ -201,7 +201,7 @@ public static class GameExecution {
 		}
 
 		Debug.Assert(apow >= dpow);
-		bool hasBreak = lane.attackerStack.cards.Any(x => x.value == Value.BREAK) || lane.defenderStack.cards.Any(x => x.value == Value.BREAK);
+		bool hasBreak = lane.attackerStack.cards.Any(x => x.Value == Value.BREAK) || lane.defenderStack.cards.Any(x => x.Value == Value.BREAK);
 		lane.attackerStack.cards.MoveAllTo(context.board[XA].cards);
 		int damage = hasBreak ? Math.Max(lane.defenderStack.cards.Count, apow) : apow - dpow + 1;
 		/* BINLOG: record damage here */
@@ -245,7 +245,7 @@ public static class GameExecution {
 
 	private static void DiscardBounces(GameContext context, Cell scanDeck, Cell discardDeck) {
 		for(int i = 0; i < scanDeck.cards.Count; i++) {
-			if(scanDeck.cards[i].value != Value.BOUNCE)
+			if(scanDeck.cards[i].Value != Value.BOUNCE)
 				continue;
 			discardDeck.cards.Add(scanDeck.cards.Take(i)!.Value);
 			i--;
@@ -256,12 +256,12 @@ public static class GameExecution {
 		int cardSum = 0;
 		int wildCount = 0;
 		foreach(Card card in stack.cards) {
-			switch(card.value) {
+			switch(card.Value) {
 				case Value.WILD:
 					wildCount++;
 					break;
 				case >= Value.TWO and <= Value.TEN:
-					cardSum += (int) card.value;
+					cardSum += (int) card.Value;
 					break;
 			}
 		}

--- a/BinaryMatrixEngine/NativeBinCmdParser.cs
+++ b/BinaryMatrixEngine/NativeBinCmdParser.cs
@@ -45,13 +45,13 @@ public static class NativeBinCmdParser {
 	}
 
 	private static CardSpecification? ParseCard(string input, out int nextIndex) {
-		Value? value = Card.ValueFromSymbol(input[0]);
+		Value? value = CardID.ValueFromSymbol(input[0]);
 		if(value == null) {
 			nextIndex = 0;
 			return null;
 		}
 
-		Axiom? axiom = Card.AxiomFromSymbol(input[1]);
+		Axiom? axiom = CardID.AxiomFromSymbol(input[1]);
 		nextIndex = axiom == null ? 1 : 2;
 		return new CardSpecification(value, axiom);
 	}

--- a/BinaryMatrixEngine/Player.cs
+++ b/BinaryMatrixEngine/Player.cs
@@ -59,12 +59,12 @@ public readonly struct CardSpecification {
 
 	public bool Matches(Card card) {
 		if(this.value != null) {
-			if(this.value != card.value)
+			if(this.value != card.Value)
 				return false;
 		}
 
 		if(this.axiom != null) {
-			if(this.axiom != card.axiom)
+			if(this.axiom != card.Axiom)
 				return false;
 		}
 

--- a/BinaryMatrixEngineAccessor/CommandExecution.cs
+++ b/BinaryMatrixEngineAccessor/CommandExecution.cs
@@ -116,7 +116,7 @@ public class CommandExecution {
 
 	public static void WriteCard(Card card) {
 		WriteWithColor(
-			card.axiom switch {
+			card.Axiom switch {
 				Axiom.DATA => ConsoleColor.Gray,
 				Axiom.KIN => ConsoleColor.Cyan,
 				Axiom.FORM => ConsoleColor.Green,


### PR DESCRIPTION
This splits out the `axiom`/`value` of a `Card` into its own struct, `CardID`, to allow for _naming_ a card without _referring_ to a specific instance of it.

Semantically, a `CardID` is the name of a card (e.g. `>%`, "BREAK of KIN"), whereas a `Card` is a _specific instance_ of a card with that name.
(such that if, _and only if_, you have an instance of a `Card`, you actually have something you can play in the game)

---

Preparation work for binlog (#5).