### PR TITLE
Drop `GameType`

### DIFF
--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -35,7 +35,7 @@ public sealed class GameContext : IDisposable {
 
 	public PlayerRole? Victor { get; private set; }
 
-	private GameContext(bool _, IEnumerable<Player> players, RNG rng, GameHooks? hooks) {
+	private GameContext(IEnumerable<Player> players, RNG rng, GameHooks? hooks, GameBoard board, List<TurnLog> binlog) {
 		/* fallbacks */
 		this.Attackers = ImmutableList<Player>.Empty;
 		this.Defenders = ImmutableList<Player>.Empty;
@@ -51,18 +51,17 @@ public sealed class GameContext : IDisposable {
 		}
 		this.rng = rng;
 		this.hooks = hooks ?? GameHooks.Default;
+		this.board = board;
+		this.binlog = binlog;
 	}
 
-	public GameContext(IEnumerable<Player> players, RNG rng, GameHooks? hooks = null) : this(true, players, rng, hooks) {
-		this.board = new GameBoard();
-		this.binlog = new List<TurnLog>();
-	}
+	public GameContext(IEnumerable<Player> players, RNG rng, GameHooks? hooks = null)
+		: this(players, rng, hooks, new GameBoard(), new List<TurnLog>()) { }
 
-	public GameContext(GameState state, IEnumerable<Player> players, RNG rng, GameHooks? hooks = null) : this(true, players, rng, hooks) {
+	public GameContext(GameState state, IEnumerable<Player> players, RNG rng, GameHooks? hooks = null)
+		: this(players, rng, hooks, state.board.Copy(), new List<TurnLog>(state.binlog)) {
 		this.TurnCounter = state.turnCounter;
 		this.Victor = state.victor;
-		this.board = state.board.Copy();
-		this.binlog = new List<TurnLog>(state.binlog);
 	}
 
 	public void Setup() {

--- a/BinaryMatrixEngineAccessor/Program.cs
+++ b/BinaryMatrixEngineAccessor/Program.cs
@@ -8,7 +8,7 @@ public static class Program {
 		ConsolePlayer attacker = new(PlayerRole.ATTACKER);
 		ConsolePlayer defender = new(PlayerRole.DEFENDER);
 
-		GameContext context = new(GameType.ASYNC, new[] { attacker, defender }, new RandomRNG(new Random(1024)));
+		GameContext context = new(new[] { attacker, defender }, new RandomRNG(new Random(1024)));
 
 		context.Setup();
 


### PR DESCRIPTION
This was a single-valued enum that is honestly completely superseded by the `GameHooks` system. There's no need for it.