### PR TITLE
Rework Player Handling

### DIFF
--- a/BinaryMatrixEngine/BinlogRenderers/TraditionalBinlogRenderer.cs
+++ b/BinaryMatrixEngine/BinlogRenderers/TraditionalBinlogRenderer.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Fayti1703.CommonLib;
 using Fayti1703.CommonLib.Enumeration;
 
 namespace BinaryMatrix.Engine.BinlogRenderers;

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -55,10 +55,10 @@ public sealed class GameContext : IDisposable {
 		this.binlog = binlog;
 	}
 
-	public GameContext(IEnumerable<Player> players, RNG rng, GameHooks? hooks = null)
+	public GameContext(IEnumerable<Player> players, RNG rng, GameHooks hooks)
 		: this(players, rng, hooks, new GameBoard(), new List<TurnLog>()) { }
 
-	public GameContext(GameState state, IEnumerable<Player> players, RNG rng, GameHooks? hooks = null)
+	public GameContext(GameState state, IEnumerable<Player> players, RNG rng, GameHooks hooks)
 		: this(players, rng, hooks, state.board.Copy(), new List<TurnLog>(state.binlog)) {
 		this.TurnCounter = state.turnCounter;
 		this.Victor = state.victor;

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -197,7 +197,7 @@ public struct GameHooks {
 			if(player.actor is ActionablePlayerActor actionableActor) {
 				yield return (player, actionableActor.GetAndConsumeAction());
 			} else {
-				throw new Exception("Cannot handle an unactionable actor via LegacyGetPlayerActions!");
+				throw new Exception("Cannot handle an non-ActionablePlayerActor via LegacyGetPlayerActions!");
 			}
 		}
 	}

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -156,21 +156,21 @@ public struct GameHooks {
 
 	static GameHooks() {
 		Default = new GameHooks {
-			PreGamePrep = DefaultPreGamePrep,
-			PreTurn = DefaultPreTurn,
-			PostTurn = DefaultPostTurn
+			PreGamePrep = StandardPreGamePrep,
+			PreTurn = NoopPreTurn,
+			PostTurn = AsyncPostTurn
 		};
 	}
 
-	private static void DefaultPreTurn(GameContext context) { /* do nothing */ }
+	public static void NoopPreTurn(GameContext context) { /* do nothing */ }
 
-	private static void DefaultPostTurn(GameContext context) {
+	public static void AsyncPostTurn(GameContext context) {
 		if(context is { TurnCounter: 109 }) {
 			context.SetVictor(PlayerRole.DEFENDER);
 		}
 	}
 
-	private static void DefaultPreGamePrep(GameContext context) {
+	public static void StandardPreGamePrep(GameContext context) {
 		using CardList cards = GameExecution.FisherYatesShuffle(context.rng, Card.allCards);
 		int j = 0;
 		for(int i = 0; i < 13; i++) {

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -93,10 +93,7 @@ public sealed class GameContext : IDisposable {
 		{
 			List<ActionLog> actions = new();
 			HashSet<Cell> drawnDecks = new();
-			foreach(
-				(Player player, ActionSet action) in
-				this.hooks.GetActions(this, activePlayers)
-			) {
+			foreach((Player player, ActionSet action) in this.hooks.GetActions(this, activePlayers)) {
 				GameExecution.ExecutePlayerTurn(this, player, action, drawnDecks, out ActionLog actionLog);
 				actions.Add(actionLog);
 				if(this.Victor != null) break;

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -3,7 +3,7 @@ using JetBrains.Annotations;
 
 namespace BinaryMatrix.Engine;
 
-public struct GameState {
+public readonly struct GameState {
 	public readonly int turnCounter;
 	public readonly GameBoard board;
 	public readonly IReadOnlyList<PlayerData> players;

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -150,9 +150,9 @@ public struct GameHooks {
 	public delegate void PreTurnType(GameContext context);
 	public delegate void PostTurnType(GameContext context);
 
-	public PreGamePrepType PreGamePrep;
-	public PreTurnType PreTurn;
-	public PostTurnType PostTurn;
+	public required PreGamePrepType PreGamePrep;
+	public required PreTurnType PreTurn;
+	public required PostTurnType PostTurn;
 
 	static GameHooks() {
 		Default = new GameHooks {

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using Fayti1703.CommonLib.Enumeration;
 using JetBrains.Annotations;
 
 namespace BinaryMatrix.Engine;
@@ -118,10 +117,9 @@ public sealed class GameContext : IDisposable {
 		this.board.Dispose();
 	}
 
+	[Obsolete("Access the player's ID property directly")]
 	public PlayerID GetPlayerID(Player player) {
-		IReadOnlyList<Player> containingList = player.Role == PlayerRole.ATTACKER ? this.Attackers : this.Defenders;
-		/* ``IReadOnlyList`1`` doesn't have an `IndexOf`, so... */
-		return new PlayerID(player.Role, containingList.WithIndex().Single(x => x.value == player).index);
+		return player.ID;
 	}
 }
 
@@ -141,6 +139,7 @@ public class RandomRNG : RNG {
 
 [PublicAPI]
 public struct GameHooks {
+	[Obsolete("Create your own GameHooks instead.")]
 	public static readonly GameHooks Default;
 
 	public delegate void PreGamePrepType(GameContext context);
@@ -192,6 +191,14 @@ public struct GameHooks {
 		}
 	}
 
-	private static IEnumerable<(Player player, ActionSet action)> LegacyGetPlayerActions(GameContext context, IEnumerable<Player> activePlayers) =>
-		activePlayers.Select(player => (player, player.GetAndConsumeAction()));
+	[Obsolete("Implement your own `GetActions` hook instead. This method may disappear in future.")]
+	public static IEnumerable<(Player player, ActionSet action)> LegacyGetPlayerActions(GameContext context, IEnumerable<Player> activePlayers) {
+		foreach(Player player in activePlayers) {
+			if(player.actor is ActionablePlayerActor actionableActor) {
+				yield return (player, actionableActor.GetAndConsumeAction());
+			} else {
+				throw new Exception("Cannot handle an unactionable actor via LegacyGetPlayerActions!");
+			}
+		}
+	}
 }

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -116,11 +116,6 @@ public sealed class GameContext : IDisposable {
 	public void Dispose() {
 		this.board.Dispose();
 	}
-
-	[Obsolete("Access the player's ID property directly")]
-	public PlayerID GetPlayerID(Player player) {
-		return player.ID;
-	}
 }
 
 public interface RNG {

--- a/BinaryMatrixEngine/GameExecution.cs
+++ b/BinaryMatrixEngine/GameExecution.cs
@@ -52,7 +52,7 @@ public static class GameExecution {
 	}
 
 	public static OperationError ExecutePlayerAction(GameContext context, Player player, ActionSet action, HashSet<Cell> drawnDecks, out ActionLog log) {
-		log = new ActionLog(context.GetPlayerID(player), new ResolvedActionSet(ActionType.NONE), null);
+		log = new ActionLog(player.ID, new ResolvedActionSet(ActionType.NONE), null);
 		switch(action.type) {
 			case ActionType.NONE:
 				log = new ActionLog(log.whoDidThis, new ResolvedActionSet(ActionType.NONE, explicitNone: true), null);
@@ -297,7 +297,7 @@ public static class GameExecution {
 
 		if(damage > 0) {
 			if(player.Role == PlayerRole.ATTACKER) {
-				PlayerID attackerID = context.GetPlayerID(player);
+				PlayerID attackerID = player.ID;
 				while(damage > 0) {
 					if(!TryDraw(context, lane.laneDeck, player, out CardID logCard)) {
 						context.SetVictor(PlayerRole.ATTACKER);

--- a/BinaryMatrixEngine/GameExecution.cs
+++ b/BinaryMatrixEngine/GameExecution.cs
@@ -23,7 +23,7 @@ public static class GameExecution {
 	public static void ExecutePlayerTurn(GameContext context, Player player, ActionSet action, HashSet<Cell> drawnDecks, out ActionLog log) {
 		OperationError error = ExecutePlayerAction(context, player, action, drawnDecks, out log);
 		if(error != OperationError.NONE) {
-			player.ReportOperationError(error);
+			player.actor.ReportOperationError(error);
 			player.InvalidOperationCount++;
 			if(player.InvalidOperationCount == 2) {
 				SuccessiveInvalidOperationSteps(context, player);

--- a/BinaryMatrixEngine/Player.cs
+++ b/BinaryMatrixEngine/Player.cs
@@ -71,4 +71,8 @@ public readonly struct PlayerID {
 		this.role = role;
 		this.index = index;
 	}
+
+	override public string ToString() {
+		return (this.role == PlayerRole.ATTACKER ? 'a' : 'd') + this.index.ToString();
+	}
 }

--- a/BinaryMatrixEngine/Player.cs
+++ b/BinaryMatrixEngine/Player.cs
@@ -52,15 +52,71 @@ public interface CardSpecification {
 	public int? ResolveForPlayer(Player player);
 }
 
-public interface Player : IDisposable {
-	public PlayerRole Role { get; }
+public class PlayerData : IDisposable {
+	public readonly PlayerID id;
+	public int invalidOperationCount;
+	public readonly CardList hand;
 
-	public ActionSet GetAndConsumeAction();
+	public PlayerData(PlayerID id, CardList? hand = null) {
+		this.id = id;
+		this.hand = hand ?? new CardList();
+	}
 
+	public void Dispose() {
+		this.hand.Dispose();
+	}
+
+	public PlayerData Copy() {
+		return new PlayerData(this.id, new CardList(this.hand)) {
+			invalidOperationCount = this.invalidOperationCount
+		};
+	}
+}
+
+public sealed class Player : IDisposable {
+	public Player(
+		PlayerRole role,
+		int index,
+		PlayerActor actor,
+		CardList? hand = null
+	) : this(new PlayerID(role, index), actor, hand) {}
+
+	public Player(
+		PlayerID id,
+		PlayerActor actor,
+		CardList? hand = null
+	) : this(new PlayerData(id, hand), actor) { }
+
+	public Player(PlayerData data, PlayerActor actor) {
+		this.data = data;
+		this.actor = actor;
+	}
+
+	public readonly PlayerData data;
+
+	public PlayerID ID => this.data.id;
+	public PlayerRole Role => this.ID.role;
+	public int InvalidOperationCount {
+		get => this.data.invalidOperationCount;
+		set => this.data.invalidOperationCount = value;
+	}
+	public CardList Hand => this.data.hand;
+
+	public readonly PlayerActor actor;
+
+	public void Dispose() {
+		this.data.Dispose();
+		this.actor.Dispose();
+	}
+}
+
+public interface PlayerActor : IDisposable {
 	public void ReportOperationError(OperationError error);
+}
 
-	public int InvalidOperationCount { get; set; }
-	public CardList Hand { get; }
+[Obsolete("Implement your own `GetActions` hook instead of relying on this interface.")]
+public interface ActionablePlayerActor : PlayerActor {
+	public ActionSet GetAndConsumeAction();
 }
 
 public readonly struct PlayerID {

--- a/BinaryMatrixEngineAccessor/CommandExecution.cs
+++ b/BinaryMatrixEngineAccessor/CommandExecution.cs
@@ -5,7 +5,7 @@ namespace BinaryMatrix.Accessor;
 
 public class CommandExecution {
 	/* FIXME?: This doesn't support multiple players per side yet */
-	public static void RunCommand(GameContext game, ConsolePlayer activePlayer, string cmd) {
+	public static void RunCommand(GameContext game, Player activePlayer, string cmd) {
 		if(cmd.Length == 0) return;
 		switch(cmd[0]) {
 			case '/':
@@ -18,8 +18,7 @@ public class CommandExecution {
 					Console.WriteLine("Could not parse your input.");
 					return;
 				}
-
-				activePlayer.action = action.Value;
+				((ConsolePlayerActor) activePlayer.actor).action = action.Value;
 				goto case '-';
 			case '-':
 				game.Tick();
@@ -27,7 +26,7 @@ public class CommandExecution {
 		}
 	}
 
-	private static void RunMetaCommand(GameContext game, ConsolePlayer activePlayer, string cmd) {
+	private static void RunMetaCommand(GameContext game, Player activePlayer, string cmd) {
 		switch(cmd) {
 			#if false
 			case "full-state":
@@ -51,14 +50,14 @@ public class CommandExecution {
 		}
 	}
 
-	public static void PrintPrompt(GameContext game, ConsolePlayer activePlayer) {
+	public static void PrintPrompt(GameContext game, Player activePlayer) {
 		PrintHeader(game);
 		PrintHand(activePlayer);
 
 		PrintBoard(game.board);
 	}
 
-	private static void PrintHand(ConsolePlayer activePlayer) {
+	private static void PrintHand(Player activePlayer) {
 		Console.Write("h{0}0: ", activePlayer.Role == PlayerRole.ATTACKER ? "a" : "d");
 		WriteCards(activePlayer.Hand);
 		Console.Write("\n");

--- a/BinaryMatrixEngineAccessor/CommandExecution.cs
+++ b/BinaryMatrixEngineAccessor/CommandExecution.cs
@@ -5,7 +5,7 @@ namespace BinaryMatrix.Accessor;
 
 public class CommandExecution {
 	/* FIXME?: This doesn't support multiple players per side yet */
-	public static void RunCommand(GameContext game, Player activePlayer, string cmd) {
+	public static void RunCommand(GameContext game, ConsolePlayerActor activePlayer, string cmd) {
 		if(cmd.Length == 0) return;
 		switch(cmd[0]) {
 			case '/':
@@ -18,7 +18,7 @@ public class CommandExecution {
 					Console.WriteLine("Could not parse your input.");
 					return;
 				}
-				((ConsolePlayerActor) activePlayer.actor).action = action.Value;
+				activePlayer.action = action.Value;
 				goto case '-';
 			case '-':
 				game.Tick();
@@ -26,7 +26,7 @@ public class CommandExecution {
 		}
 	}
 
-	private static void RunMetaCommand(GameContext game, Player activePlayer, string cmd) {
+	private static void RunMetaCommand(GameContext game, ConsolePlayerActor activePlayer, string cmd) {
 		switch(cmd) {
 			#if false
 			case "full-state":
@@ -37,10 +37,10 @@ public class CommandExecution {
 				PrintBoard(game.board);
 				break;
 			case "hand":
-				PrintHand(activePlayer);
+				PrintHand(activePlayer.player);
 				break;
 			case "prompt":
-				PrintPrompt(game, activePlayer);
+				PrintPrompt(game, activePlayer.player);
 				break;
 			case "macro1":
 				Macros.RunMacro(game, Macros.Macro1);

--- a/BinaryMatrixEngineAccessor/ConsolePlayer.cs
+++ b/BinaryMatrixEngineAccessor/ConsolePlayer.cs
@@ -3,14 +3,8 @@ using static Fayti1703.CommonLib.Misc;
 
 namespace BinaryMatrix.Accessor;
 
-public class ConsolePlayer : Player {
+public class ConsolePlayerActor : ActionablePlayerActor {
 	public ActionSet action;
-
-	public ConsolePlayer(PlayerRole role) {
-		this.Role = role;
-	}
-
-	public PlayerRole Role { get; }
 
 	public ActionSet GetAndConsumeAction() => Exchange(ref this.action, ActionSet.NONE);
 
@@ -18,12 +12,6 @@ public class ConsolePlayer : Player {
 		Console.WriteLine("Your operation did not succeed. Error code: " + error);
 	}
 
-	public int InvalidOperationCount { get; set; }
-
-	public CardList Hand { get; } = new();
-
-	public void Dispose() {
-		this.Hand.Dispose();
-	}
+	public void Dispose() {}
 
 }

--- a/BinaryMatrixEngineAccessor/ConsolePlayer.cs
+++ b/BinaryMatrixEngineAccessor/ConsolePlayer.cs
@@ -4,6 +4,7 @@ using static Fayti1703.CommonLib.Misc;
 namespace BinaryMatrix.Accessor;
 
 public class ConsolePlayerActor : ActionablePlayerActor {
+	public Player player = null!;
 	public ActionSet action;
 
 	public ActionSet GetAndConsumeAction() => Exchange(ref this.action, ActionSet.NONE);

--- a/BinaryMatrixEngineAccessor/Macros.cs
+++ b/BinaryMatrixEngineAccessor/Macros.cs
@@ -29,8 +29,8 @@ public static class Macros {
 
 	public static void RunMacro(GameContext context, ActionSet[] actions) {
 		foreach(ActionSet action in actions) {
-			ConsolePlayer player = (ConsolePlayer) (context.TurnCounter % 2 == 0 ? context.Defenders.First() : context.Attackers.First());
-			player.action = action;
+			Player player = context.TurnCounter % 2 == 0 ? context.Defenders.First() : context.Attackers.First();
+			((ConsolePlayerActor) player.actor).action = action;
 			context.Tick();
 		}
 	}

--- a/BinaryMatrixEngineAccessor/Macros.cs
+++ b/BinaryMatrixEngineAccessor/Macros.cs
@@ -29,7 +29,7 @@ public static class Macros {
 
 	public static void RunMacro(GameContext context, ActionSet[] actions) {
 		foreach(ActionSet action in actions) {
-			Player player = context.TurnCounter % 2 == 0 ? context.Defenders.First() : context.Attackers.First();
+			Player player = context.TurnCounter % 2 == 0 ? context.Defenders[0] : context.Attackers[0];
 			((ConsolePlayerActor) player.actor).action = action;
 			context.Tick();
 		}

--- a/BinaryMatrixEngineAccessor/Program.cs
+++ b/BinaryMatrixEngineAccessor/Program.cs
@@ -8,7 +8,7 @@ public static class Program {
 		ConsolePlayer attacker = new(PlayerRole.ATTACKER);
 		ConsolePlayer defender = new(PlayerRole.DEFENDER);
 
-		GameContext context = new(new[] { attacker, defender }, new RandomRNG(new Random(1024)));
+		GameContext context = new(new[] { attacker, defender }, new RandomRNG(new Random(1024)), GameHooks.Default);
 
 		context.Setup();
 

--- a/BinaryMatrixEngineAccessor/Program.cs
+++ b/BinaryMatrixEngineAccessor/Program.cs
@@ -5,10 +5,12 @@ namespace BinaryMatrix.Accessor;
 public static class Program {
 	public static void Main() {
 
-		Player attacker = new(new PlayerID(PlayerRole.ATTACKER, 0), new ConsolePlayerActor());
-		Player defender = new(new PlayerID(PlayerRole.DEFENDER, 0), new ConsolePlayerActor());
+		ConsolePlayerActor attacker = new();
+		attacker.player = new Player(new PlayerID(PlayerRole.ATTACKER, 0), attacker);
+		ConsolePlayerActor defender = new();
+		defender.player = new Player(new PlayerID(PlayerRole.DEFENDER, 0), defender);
 
-		GameContext context = new(new[] { attacker, defender }, new RandomRNG(new Random(1024)), GameHooks.Default);
+		GameContext context = new(new[] { attacker.player, defender.player }, new RandomRNG(new Random(1024)), GameHooks.Default);
 
 		context.Setup();
 
@@ -16,7 +18,7 @@ public static class Program {
 		while(context.Victor == null) {
 			bool isDef = context.TurnCounter % 2 == 0;
 			if(context.TurnCounter != lastTurnCounter) {
-				CommandExecution.PrintPrompt(context, isDef ? defender : attacker);
+				CommandExecution.PrintPrompt(context, (isDef ? defender : attacker).player);
 				lastTurnCounter = context.TurnCounter;
 			}
 			string? cmd;

--- a/BinaryMatrixEngineAccessor/Program.cs
+++ b/BinaryMatrixEngineAccessor/Program.cs
@@ -5,8 +5,8 @@ namespace BinaryMatrix.Accessor;
 public static class Program {
 	public static void Main() {
 
-		ConsolePlayer attacker = new(PlayerRole.ATTACKER);
-		ConsolePlayer defender = new(PlayerRole.DEFENDER);
+		Player attacker = new(new PlayerID(PlayerRole.ATTACKER, 0), new ConsolePlayerActor());
+		Player defender = new(new PlayerID(PlayerRole.DEFENDER, 0), new ConsolePlayerActor());
 
 		GameContext context = new(new[] { attacker, defender }, new RandomRNG(new Random(1024)), GameHooks.Default);
 


### PR DESCRIPTION
This started as a simple "fix #12" branch, but turned into a complete rework of how `Player`s are represented.

Highlights:
* `Player` is now a simple two-element composition of a `PlayerData` (struct holding all the player's game data) and a `PlayerActor` (interface for the host to mess with)
* `PlayerID` is now stored on the `PlayerData`, rather than being derived from list position every time.
* Added a `GetActions` game hook; this is the "fix #12" part.
* `PlayerData` is now saved in `GameState`.


---

This PR breaks backwards compatibility, a lot.
* `Player` has been entirely rewritten
* Method `GameContext::GetPlayerID` has been dropped
* A `GameHooks` parameter is now required when  constructing `GameContext`
* `GameHooks` fields are `required`
* A new `required` field (`GetActions`) was added to `GameHooks`

---
Fixes #12 