### PR TITLE
Correct binlog on attacker victory draw

### DIFF
--- a/BinaryMatrixEngine/GameExecution.cs
+++ b/BinaryMatrixEngine/GameExecution.cs
@@ -82,13 +82,13 @@ public static class GameExecution {
 							new ResolvedActionSet(ActionType.DRAW, action.lane),
 							ImmutableList<CardMoveLog>.Empty
 						);
+					} else {
+						log = new ActionLog(
+							log.whoDidThis,
+							new ResolvedActionSet(ActionType.DRAW, action.lane),
+							CardMoveLog.SingleMove(drawnCard, log.whoDidThis)
+						);
 					}
-
-					log = new ActionLog(
-						log.whoDidThis,
-						new ResolvedActionSet(ActionType.DRAW, action.lane),
-						CardMoveLog.SingleMove(drawnCard, log.whoDidThis)
-					);
 				}
 			} break;
 			case ActionType.PLAY:


### PR DESCRIPTION
Fixes the binlog displaying `CardID.Unknown` instead of an empty list if an attacker wins by drawing the final card out of a lane.

With thanks to @samualtnorman.