### PR TITLE
Fix flipped condition in ActionLogComparer

### DIFF
--- a/BinaryMatrixEngine.Tests/ActionTests.cs
+++ b/BinaryMatrixEngine.Tests/ActionTests.cs
@@ -35,7 +35,7 @@ public class ActionTests {
 		Assert.AreEqual(new ActionLog(
 			whoDidThis: new PlayerID(PlayerRole.ATTACKER, 0),
 			resolvedAction: new ResolvedActionSet(ActionType.DRAW, ActionSet.LANE_A),
-			moveResults: CardMoveLog.SingleMove(new CardID(BOUNCE, KIN), new PlayerID(PlayerRole.ATTACKER, 0))
+			moveResults: CardMoveLog.SingleMove(CardID.Unknown, new PlayerID(PlayerRole.ATTACKER, 0))
 		), log, Comparers.ActionLog);
 
 		GameBoard expectedBoard = new();

--- a/BinaryMatrixEngine.Tests/GameComparers.cs
+++ b/BinaryMatrixEngine.Tests/GameComparers.cs
@@ -96,7 +96,7 @@ public class ActionLogComparer : IEqualityComparer<ActionLog> {
 	public bool Equals(ActionLog x, ActionLog y) {
 		if(!x.whoDidThis.Equals(y.whoDidThis))  return false;
 		if(!x.resolvedAction.Equals(y.resolvedAction)) return false;
-		if(this.moveLogComparer.Equals(x.moveResults, y.moveResults)) return false;
+		if(!this.moveLogComparer.Equals(x.moveResults, y.moveResults)) return false;
 		if((x.combatLog == null) != (y.combatLog == null)) return false;
 		return x.combatLog == null || this.combatLogComparer.Equals(x.combatLog.Value, y.combatLog!.Value);
 	}


### PR DESCRIPTION
Fixes the comparer returning `true` for `ActionLog`s whose `moveResults` did not compare equal, and `false` for ones for which they did compare equal.

Also fixes a test case broken by this. The test case was 'obviously wrong', as explained in the commit message.