### PR TITLE
Make `GameState` more read-only

### DIFF
--- a/BinaryMatrixEngine/GameBoard.cs
+++ b/BinaryMatrixEngine/GameBoard.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Fayti1703.CommonLib.Enumeration;
 using JetBrains.Annotations;
 
@@ -84,7 +85,7 @@ public sealed class GameBoard : IDisposable {
 	private readonly IReadOnlyList<Cell> cells;
 
 	public GameBoard() {
-		this.cells = Enum.GetValues<CellName>().Select(x => new Cell(x)).ToList();
+		this.cells = Enum.GetValues<CellName>().Select(x => new Cell(x)).ToImmutableList();
 	}
 
 	public Cell GetCell(CellName name) {

--- a/BinaryMatrixEngine/GameBoard.cs
+++ b/BinaryMatrixEngine/GameBoard.cs
@@ -27,6 +27,11 @@ public sealed class Cell : IDisposable {
 		});
 	}
 
+	internal Cell(CellName name, IEnumerable<Card> cards) {
+		this.name = name;
+		this.cards = new CardList(cards);
+	}
+
 	public bool Revealed {
 		get => this.name switch {
 			>= X0 and <= X5 => true,
@@ -88,6 +93,11 @@ public sealed class GameBoard : IDisposable {
 		this.cells = Enum.GetValues<CellName>().Select(x => new Cell(x)).ToImmutableList();
 	}
 
+	public GameBoard(IReadOnlyCollection<IEnumerable<Card>> stacks) {
+		if(stacks.Count != Enum.GetValues<CellName>().Length) throw new ArgumentException("Invalid number of stacks", nameof(stacks));
+		this.cells = stacks.Select((x, i) => new Cell((CellName) i, x)).ToImmutableList();
+	}
+
 	public Cell GetCell(CellName name) {
 		return this.cells[(int) name];
 	}
@@ -115,6 +125,8 @@ public sealed class GameBoard : IDisposable {
 
 		return newBoard;
 	}
+
+	public IReadOnlyList<IEnumerable<Card>> GetStacks() => this.cells.Select(x => x.cards).ToImmutableList();
 
 	public void Dispose() {
 		foreach(Cell cell in this.cells) {

--- a/BinaryMatrixEngine/GameContext.cs
+++ b/BinaryMatrixEngine/GameContext.cs
@@ -5,7 +5,7 @@ namespace BinaryMatrix.Engine;
 
 public readonly struct GameState {
 	public readonly int turnCounter;
-	public readonly GameBoard board;
+	public readonly IReadOnlyList<IEnumerable<Card>> board;
 	public readonly IReadOnlyList<PlayerData> players;
 	public readonly PlayerRole? victor;
 	public readonly IReadOnlyList<TurnLog> binlog;
@@ -13,7 +13,7 @@ public readonly struct GameState {
 	public GameState(
 		int turnCounter,
 		IReadOnlyList<PlayerData> players,
-		GameBoard board,
+		IReadOnlyList<IEnumerable<Card>> board,
 		PlayerRole? victor,
 		IReadOnlyList<TurnLog> binlog
 	) {
@@ -75,7 +75,7 @@ public sealed class GameContext : IDisposable {
 		: this(players, rng, hooks, new GameBoard(), new List<TurnLog>()) { }
 
 	public GameContext(GameState state, IReadOnlyDictionary<PlayerID, PlayerActor> actors, RNG rng, GameHooks hooks)
-		: this(state.CreatePlayers(actors), rng, hooks, state.board.Copy(), new List<TurnLog>(state.binlog)) {
+		: this(state.CreatePlayers(actors), rng, hooks, new GameBoard(state.board), new List<TurnLog>(state.binlog)) {
 		this.TurnCounter = state.turnCounter;
 		this.Victor = state.victor;
 	}
@@ -98,7 +98,7 @@ public sealed class GameContext : IDisposable {
 		return new GameState(
 			this.TurnCounter,
 			this.Players.Select(x => x.data.Copy()).ToImmutableList(),
-			this.board.Copy(),
+			this.board.GetStacks(),
 			this.Victor,
 			this.binlog.ToImmutableList()
 		);


### PR DESCRIPTION
Currently, you can inadvertently modify a `GameState` by messing with its `GameBoard`.  `GameState` is meant to be an immutable snapshot of a game state, so this is problematic.

---

Includes some other refactoring that may be pulled in separately.